### PR TITLE
Organization namespace has to be all lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Organization namespace has to be all lowercase.
+
 ## [0.5.0] - 2020-09-24
 
 ### Changed

--- a/service/controller/resource/organization/resource.go
+++ b/service/controller/resource/organization/resource.go
@@ -2,6 +2,7 @@ package organization
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
@@ -62,7 +63,7 @@ func (r *Resource) Name() string {
 func newOrganizationNamespace(organizationName string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s%s", organizationNamePrefix, organizationName),
+			Name: fmt.Sprintf("%s%s", organizationNamePrefix, strings.ToLower(organizationName)),
 			Labels: map[string]string{
 				label.Organization: organizationName,
 				label.ManagedBy:    project.Name(),


### PR DESCRIPTION
In case of organizations with uppercase letters, the namespace should be lowercased