### PR TITLE
organizations: take into account `companyd` orgs when creating/updating/deleting org CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Also delete legacy `companyd` organizations when deleting `Organization` CRs.
+- Prevent deleting legacy credentials when deleting `Organization` CRs.
+
 ## [0.5.0] - 2020-09-24
 
 ### Changed

--- a/flag/service/legacycredentials/legacycredentials.go
+++ b/flag/service/legacycredentials/legacycredentials.go
@@ -1,0 +1,7 @@
+package legacycredentials
+
+// LegacyCredentials holds configuration specific to the oldschool
+// credentiald service.
+type LegacyCredentials struct {
+	Address string
+}

--- a/flag/service/legacyorganizations/legacyorganizations.go
+++ b/flag/service/legacyorganizations/legacyorganizations.go
@@ -1,0 +1,7 @@
+package legacyorganizations
+
+// LegacyOrganizations holds configuration specific to the oldschool
+// companyd organization service.
+type LegacyOrganizations struct {
+	Address string
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"github.com/giantswarm/operatorkit/v2/pkg/flag/service/kubernetes"
 
+	"github.com/giantswarm/organization-operator/flag/service/legacycredentials"
 	"github.com/giantswarm/organization-operator/flag/service/legacyorganizations"
 )
 
@@ -10,4 +11,5 @@ import (
 type Service struct {
 	Kubernetes          kubernetes.Kubernetes
 	LegacyOrganizations legacyorganizations.LegacyOrganizations
+	LegacyCredentials   legacycredentials.LegacyCredentials
 }

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"github.com/giantswarm/operatorkit/v2/pkg/flag/service/kubernetes"
+
 	"github.com/giantswarm/organization-operator/flag/service/legacyorganizations"
 )
 

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -2,9 +2,11 @@ package service
 
 import (
 	"github.com/giantswarm/operatorkit/v2/pkg/flag/service/kubernetes"
+	"github.com/giantswarm/organization-operator/flag/service/legacyorganizations"
 )
 
 // Service is an intermediate data structure for command line configuration flags.
 type Service struct {
-	Kubernetes kubernetes.Kubernetes
+	Kubernetes          kubernetes.Kubernetes
+	LegacyOrganizations legacyorganizations.LegacyOrganizations
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/giantswarm/companyd-client-go v0.6.1
 	github.com/giantswarm/exporterkit v0.2.1
 	github.com/giantswarm/k8sclient/v4 v4.1.0
+	github.com/giantswarm/k8smetadata v0.3.0
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/microkit v0.2.2

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/giantswarm/api-schema v0.7.1 // indirect
 	github.com/giantswarm/apiextensions/v2 v2.6.2
 	github.com/giantswarm/companyd-client-go v0.6.1
+	github.com/giantswarm/credentiald/v2 v2.0.1
 	github.com/giantswarm/exporterkit v0.2.1
 	github.com/giantswarm/k8sclient/v4 v4.1.0
 	github.com/giantswarm/k8smetadata v0.3.0
@@ -16,6 +17,7 @@ require (
 	github.com/giantswarm/operatorkit/v2 v2.0.2
 	github.com/prometheus/client_golang v1.10.0
 	github.com/spf13/viper v1.7.1
+	gopkg.in/resty.v1 v1.12.0
 	k8s.io/api v0.18.18
 	k8s.io/apimachinery v0.18.18
 	k8s.io/client-go v0.18.18

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/giantswarm/organization-operator
 go 1.14
 
 require (
+	github.com/giantswarm/api-schema v0.7.1 // indirect
 	github.com/giantswarm/apiextensions/v2 v2.6.2
+	github.com/giantswarm/companyd-client-go v0.6.1
 	github.com/giantswarm/exporterkit v0.2.1
 	github.com/giantswarm/k8sclient/v4 v4.1.0
 	github.com/giantswarm/microendpoint v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -159,11 +159,15 @@ github.com/getsentry/sentry-go v0.7.0 h1:MR2yfR4vFfv/2+iBuSnkdQwVg7N9cJzihZ6KJu7
 github.com/getsentry/sentry-go v0.7.0/go.mod h1:pLFpD2Y5RHIKF9Bw3KH6/68DeN2K/XBJd8awjdPnUwg=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/giantswarm/api-schema v0.7.1 h1:ppguvD17wx0SPSXLilfn/08UcaZ1jEx3qLFwltDaEsU=
+github.com/giantswarm/api-schema v0.7.1/go.mod h1:VRGxnyFW3X93bmjP+UR59YSvYncVRHgn1Eys7hIhzqc=
 github.com/giantswarm/apiextensions/v2 v2.0.0/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
 github.com/giantswarm/apiextensions/v2 v2.6.2 h1:ECdw6G5QCr5TN95SIFtD63PfNVS7vBnPcreqqFGIFh4=
 github.com/giantswarm/apiextensions/v2 v2.6.2/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
+github.com/giantswarm/companyd-client-go v0.6.1 h1:w0MTDHqRi/pAZwQgj5QEtwAffBgDqctSJmci/+yPEGI=
+github.com/giantswarm/companyd-client-go v0.6.1/go.mod h1:wwGHUvHpVNp9nEKjgMzO4mYoBqjp+GZMvLzoGQOMU0w=
 github.com/giantswarm/exporterkit v0.2.0/go.mod h1:b4fuHVjsvZgznC9OEPfn0y5zvN8SnEKTiI5zTTfck94=
 github.com/giantswarm/exporterkit v0.2.1 h1:M/Avqdg6O+NdyGtY+LSy5cCpJzhG15WRHQRkhOY/dKs=
 github.com/giantswarm/exporterkit v0.2.1/go.mod h1:LkZNK+2qTcbHspbizA6JBBXpQW99u7u7UisUaWrSoVY=
@@ -401,6 +405,8 @@ github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/juju/errgo v0.0.0-20140925100237-08cceb5d0b53 h1:tGpfbOOO0SV3qtMUx8O9RbJeei6VDBwnpQQ0JYIFaVg=
+github.com/juju/errgo v0.0.0-20140925100237-08cceb5d0b53/go.mod h1:ZtgUe3RyZisw/AlQjgU9DeO3hqUH9E/bkreI2FLg/QY=
 github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/loggo v0.0.0-20180524022052-584905176618/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
@@ -422,7 +428,6 @@ github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgo
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
@@ -501,6 +506,8 @@ github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
@@ -937,8 +944,9 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/go.sum
+++ b/go.sum
@@ -162,12 +162,15 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/giantswarm/api-schema v0.7.1 h1:ppguvD17wx0SPSXLilfn/08UcaZ1jEx3qLFwltDaEsU=
 github.com/giantswarm/api-schema v0.7.1/go.mod h1:VRGxnyFW3X93bmjP+UR59YSvYncVRHgn1Eys7hIhzqc=
 github.com/giantswarm/apiextensions/v2 v2.0.0/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
+github.com/giantswarm/apiextensions/v2 v2.5.1/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
 github.com/giantswarm/apiextensions/v2 v2.6.2 h1:ECdw6G5QCr5TN95SIFtD63PfNVS7vBnPcreqqFGIFh4=
 github.com/giantswarm/apiextensions/v2 v2.6.2/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
 github.com/giantswarm/companyd-client-go v0.6.1 h1:w0MTDHqRi/pAZwQgj5QEtwAffBgDqctSJmci/+yPEGI=
 github.com/giantswarm/companyd-client-go v0.6.1/go.mod h1:wwGHUvHpVNp9nEKjgMzO4mYoBqjp+GZMvLzoGQOMU0w=
+github.com/giantswarm/credentiald/v2 v2.0.1 h1:c4rXDMnXdN4zb0Vw+JYYKslMaJgMRX8B2mtrr6haLM4=
+github.com/giantswarm/credentiald/v2 v2.0.1/go.mod h1:DLQAKGE8luFoN82cq13UbwAPhJ3KP2tFIy2Eun14Nro=
 github.com/giantswarm/exporterkit v0.2.0/go.mod h1:b4fuHVjsvZgznC9OEPfn0y5zvN8SnEKTiI5zTTfck94=
 github.com/giantswarm/exporterkit v0.2.1 h1:M/Avqdg6O+NdyGtY+LSy5cCpJzhG15WRHQRkhOY/dKs=
 github.com/giantswarm/exporterkit v0.2.1/go.mod h1:LkZNK+2qTcbHspbizA6JBBXpQW99u7u7UisUaWrSoVY=
@@ -176,6 +179,8 @@ github.com/giantswarm/k8sclient/v4 v4.1.0 h1:kquaq+qAQ/x4voocbOrn3WfskojANpvg0B7
 github.com/giantswarm/k8sclient/v4 v4.1.0/go.mod h1:jTwQ8q0YbJJu3ZxbjoI6hkXeuvKm15xyI/c+zwxnUH0=
 github.com/giantswarm/k8smetadata v0.3.0 h1:ZMsKgWAZ/ZYNG15DVKclgGrH6VeENC/cSGiAb4r2H60=
 github.com/giantswarm/k8smetadata v0.3.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
+github.com/giantswarm/microclient v0.2.0 h1:K2EajsQ06rR2uykzIf4xTb7t6VOzaP67TyCpk7PmcZ8=
+github.com/giantswarm/microclient v0.2.0/go.mod h1:2p+ygmU8v7MpkTCNatiGhjOmHOOqC9fdJ0rlXI4Ulfc=
 github.com/giantswarm/microendpoint v0.2.0 h1:xCAqAVRjTw/4ifEuBeNavALdbQsLk6+k/ukzdy0GWZE=
 github.com/giantswarm/microendpoint v0.2.0/go.mod h1:SSkSp4Q4iSW7vwkil+/E3IXy9Q8To8vXmT5VCg24RDg=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
@@ -189,6 +194,7 @@ github.com/giantswarm/micrologger v0.3.1/go.mod h1:PjAgtcJ922ZMX/Aa05IPi0bdYvOj2
 github.com/giantswarm/micrologger v0.3.3/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
 github.com/giantswarm/micrologger v0.5.0 h1:/f2knkyf4bZw3L5F48R7VENiEKPb3Sjnzrg46+Ja5vk=
 github.com/giantswarm/micrologger v0.5.0/go.mod h1:J/jbt7A8eixqE40yq4JY8Hdbs/qeboe2FjHlq05UWjA=
+github.com/giantswarm/operatorkit/v2 v2.0.1/go.mod h1:xlN/LMZaQExWKwQUAI9m9xaHZCCL6WHVYGpd7Wx7LTg=
 github.com/giantswarm/operatorkit/v2 v2.0.2 h1:S2O5lZBT1yeGFfR+/so5TSIXgbgCSrVceM3EccNmoGE=
 github.com/giantswarm/operatorkit/v2 v2.0.2/go.mod h1:Bl8gK7hYhvRQP0Ds26rwYdoSXbbr+NKRZmWtwqI7HFI=
 github.com/giantswarm/to v0.3.0 h1:cEzMYkWLGI3cI8x3a0L3nPCQYJTb/cAaqcIPvxnDmpQ=

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/giantswarm/exporterkit v0.2.1/go.mod h1:LkZNK+2qTcbHspbizA6JBBXpQW99u
 github.com/giantswarm/k8sclient/v4 v4.0.0/go.mod h1:jTwQ8q0YbJJu3ZxbjoI6hkXeuvKm15xyI/c+zwxnUH0=
 github.com/giantswarm/k8sclient/v4 v4.1.0 h1:kquaq+qAQ/x4voocbOrn3WfskojANpvg0B7srhL3YSM=
 github.com/giantswarm/k8sclient/v4 v4.1.0/go.mod h1:jTwQ8q0YbJJu3ZxbjoI6hkXeuvKm15xyI/c+zwxnUH0=
+github.com/giantswarm/k8smetadata v0.3.0 h1:ZMsKgWAZ/ZYNG15DVKclgGrH6VeENC/cSGiAb4r2H60=
+github.com/giantswarm/k8smetadata v0.3.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/microendpoint v0.2.0 h1:xCAqAVRjTw/4ifEuBeNavALdbQsLk6+k/ukzdy0GWZE=
 github.com/giantswarm/microendpoint v0.2.0/go.mod h1:SSkSp4Q4iSW7vwkil+/E3IXy9Q8To8vXmT5VCg24RDg=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=

--- a/helm/organization-operator/templates/configmap.yaml
+++ b/helm/organization-operator/templates/configmap.yaml
@@ -21,3 +21,5 @@ data:
           caFile: ''
           crtFile: ''
           keyFile: ''
+      legacyorganizations:
+        address: 'http://companyd:8000'

--- a/helm/organization-operator/templates/configmap.yaml
+++ b/helm/organization-operator/templates/configmap.yaml
@@ -23,3 +23,5 @@ data:
           keyFile: ''
       legacyorganizations:
         address: 'http://companyd:8000'
+      legacycredentials:
+        address: 'http://credentiald:8000'

--- a/main.go
+++ b/main.go
@@ -108,6 +108,9 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CrtFile, "", "Certificate file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
 
+	daemonCommand.PersistentFlags().String(f.Service.LegacyOrganizations.Address, "", "The address of the companyd service.")
+	daemonCommand.PersistentFlags().String(f.Service.LegacyCredentials.Address, "", "The address of the credentiald service.")
+
 	err = newCommand.CobraCommand().Execute()
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -2,17 +2,8 @@ package key
 
 import (
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/security/v1alpha1"
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
-)
-
-const (
-	// uiName is used to identify organizations
-	// with names that don't adhere to the DNS standard.
-	//
-	// While the org CR name would be converted to the
-	// DNS standard, this annotation is used to determine
-	// the companyd counterpart of the org CR.
-	uiName = "ui.giantswarm.io/original-organization-name"
 )
 
 func ToOrganization(v interface{}) (securityv1alpha1.Organization, error) {
@@ -32,7 +23,7 @@ func ToOrganization(v interface{}) (securityv1alpha1.Organization, error) {
 
 func LegacyOrganizationName(cr *securityv1alpha1.Organization) string {
 	if cr.GetAnnotations() != nil {
-		name := cr.GetAnnotations()[uiName]
+		name := cr.GetAnnotations()[annotation.UIOriginalOrganizationName]
 		if len(name) > 0 {
 			return name
 		}

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -5,6 +5,16 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+const (
+	// uiName is used to identify organizations
+	// with names that don't adhere to the DNS standard.
+	//
+	// While the org CR name would be converted to the
+	// DNS standard, this annotation is used to determine
+	// the companyd counterpart of the org CR.
+	uiName = "ui.giantswarm.io/original-organization-name"
+)
+
 func ToOrganization(v interface{}) (securityv1alpha1.Organization, error) {
 	if v == nil {
 		return securityv1alpha1.Organization{}, microerror.Maskf(wrongTypeError, "expected non-nil, got %#v", v)
@@ -18,4 +28,15 @@ func ToOrganization(v interface{}) (securityv1alpha1.Organization, error) {
 	c := p.DeepCopy()
 
 	return *c, nil
+}
+
+func LegacyOrganizationName(cr *securityv1alpha1.Organization) string {
+	if cr.GetAnnotations() != nil {
+		name := cr.GetAnnotations()[uiName]
+		if len(name) > 0 {
+			return name
+		}
+	}
+
+	return cr.GetName()
 }

--- a/service/controller/org.go
+++ b/service/controller/org.go
@@ -11,13 +11,16 @@ import (
 	"github.com/giantswarm/operatorkit/v2/pkg/resource/wrapper/retryresource"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	companyclient "github.com/giantswarm/companyd-client-go"
+
 	"github.com/giantswarm/organization-operator/pkg/project"
 	organization "github.com/giantswarm/organization-operator/service/controller/resource/organization"
 )
 
 type OrganizationConfig struct {
-	K8sClient k8sclient.Interface
-	Logger    micrologger.Logger
+	K8sClient       k8sclient.Interface
+	Logger          micrologger.Logger
+	LegacyOrgClient *companyclient.Client
 }
 
 type Organization struct {
@@ -66,8 +69,9 @@ func newOrganizationResources(config OrganizationConfig) ([]resource.Interface, 
 	var orgResource resource.Interface
 	{
 		c := organization.Config{
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
+			K8sClient:       config.K8sClient,
+			Logger:          config.Logger,
+			LegacyOrgClient: config.LegacyOrgClient,
 		}
 
 		orgResource, err = organization.New(c)

--- a/service/controller/org.go
+++ b/service/controller/org.go
@@ -12,15 +12,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	companyclient "github.com/giantswarm/companyd-client-go"
+	credentialclient "github.com/giantswarm/credentiald/v2/client"
 
 	"github.com/giantswarm/organization-operator/pkg/project"
 	organization "github.com/giantswarm/organization-operator/service/controller/resource/organization"
 )
 
 type OrganizationConfig struct {
-	K8sClient       k8sclient.Interface
-	Logger          micrologger.Logger
-	LegacyOrgClient *companyclient.Client
+	K8sClient              k8sclient.Interface
+	Logger                 micrologger.Logger
+	LegacyOrgClient        *companyclient.Client
+	LegacyCredentialClient *credentialclient.Client
 }
 
 type Organization struct {
@@ -69,9 +71,10 @@ func newOrganizationResources(config OrganizationConfig) ([]resource.Interface, 
 	var orgResource resource.Interface
 	{
 		c := organization.Config{
-			K8sClient:       config.K8sClient,
-			Logger:          config.Logger,
-			LegacyOrgClient: config.LegacyOrgClient,
+			K8sClient:              config.K8sClient,
+			Logger:                 config.Logger,
+			LegacyOrgClient:        config.LegacyOrgClient,
+			LegacyCredentialClient: config.LegacyCredentialClient,
 		}
 
 		orgResource, err = organization.New(c)

--- a/service/controller/resource/organization/create.go
+++ b/service/controller/resource/organization/create.go
@@ -36,7 +36,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created organization namespace %#q", orgNamespace.Name))
+
 	legacyOrgName := key.LegacyOrganizationName(&org)
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating legacy organization %#q", legacyOrgName))
+
 	legacyOrgFields := companyclient.CompanyFields{
 		DefaultCluster: "deprecated",
 	}
@@ -48,6 +52,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created organization namespace %#q", orgNamespace.Name))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created legacy organization %#q", legacyOrgName))
+
 	return nil
 }

--- a/service/controller/resource/organization/delete.go
+++ b/service/controller/resource/organization/delete.go
@@ -7,6 +7,7 @@ import (
 	companyclient "github.com/giantswarm/companyd-client-go"
 	legacyCredentialLister "github.com/giantswarm/credentiald/v2/service/lister"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/v2/pkg/controller/context/finalizerskeptcontext"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/giantswarm/organization-operator/service/controller/key"
@@ -35,6 +36,9 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 	if len(legacyCredentials) > 0 {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found legacy credentials for organization %#q", legacyOrgName))
+
+		finalizerskeptcontext.SetKept(ctx)
+
 		return nil
 	}
 

--- a/service/controller/resource/organization/delete.go
+++ b/service/controller/resource/organization/delete.go
@@ -18,11 +18,15 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	}
 
 	legacyOrgName := key.LegacyOrganizationName(&org)
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting legacy organization namespace %#q", legacyOrgName))
+
 	err = r.legacyOrgClient.DeleteCompany(legacyOrgName)
 	if companyclient.IsErrCompanyNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("legacy organization %#q does not exist", legacyOrgName))
 	} else if err != nil {
 		return microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted legacy organization %#q", legacyOrgName))
 	}
 
 	orgNamespace := newOrganizationNamespace(org.Name)

--- a/service/controller/resource/organization/resource.go
+++ b/service/controller/resource/organization/resource.go
@@ -39,9 +39,10 @@ type Config struct {
 }
 
 type Resource struct {
-	k8sClient       k8sclient.Interface
-	logger          micrologger.Logger
-	legacyOrgClient *companyclient.Client
+	k8sClient              k8sclient.Interface
+	logger                 micrologger.Logger
+	legacyOrgClient        *companyclient.Client
+	legacyCredentialClient *credentialclient.Client
 }
 
 func New(config Config) (*Resource, error) {
@@ -55,11 +56,15 @@ func New(config Config) (*Resource, error) {
 	if config.LegacyOrgClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.LegacyOrgClient must not be empty", config)
 	}
+	if config.LegacyCredentialClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.LegacyCredentialClient must not be empty", config)
+	}
 
 	r := &Resource{
-		k8sClient:       config.K8sClient,
-		logger:          config.Logger,
-		legacyOrgClient: config.LegacyOrgClient,
+		k8sClient:              config.K8sClient,
+		logger:                 config.Logger,
+		legacyOrgClient:        config.LegacyOrgClient,
+		legacyCredentialClient: config.LegacyCredentialClient,
 	}
 
 	return r, nil

--- a/service/controller/resource/organization/resource.go
+++ b/service/controller/resource/organization/resource.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	companyclient "github.com/giantswarm/companyd-client-go"
+	credentialclient "github.com/giantswarm/credentiald/v2/client"
 
 	"github.com/giantswarm/organization-operator/pkg/label"
 	"github.com/giantswarm/organization-operator/pkg/project"
@@ -31,9 +32,10 @@ var (
 )
 
 type Config struct {
-	K8sClient       k8sclient.Interface
-	Logger          micrologger.Logger
-	LegacyOrgClient *companyclient.Client
+	K8sClient              k8sclient.Interface
+	Logger                 micrologger.Logger
+	LegacyOrgClient        *companyclient.Client
+	LegacyCredentialClient *credentialclient.Client
 }
 
 type Resource struct {

--- a/service/controller/resource/organization/resource.go
+++ b/service/controller/resource/organization/resource.go
@@ -9,6 +9,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	companyclient "github.com/giantswarm/companyd-client-go"
+
 	"github.com/giantswarm/organization-operator/pkg/label"
 	"github.com/giantswarm/organization-operator/pkg/project"
 )
@@ -29,13 +31,15 @@ var (
 )
 
 type Config struct {
-	K8sClient k8sclient.Interface
-	Logger    micrologger.Logger
+	K8sClient       k8sclient.Interface
+	Logger          micrologger.Logger
+	LegacyOrgClient *companyclient.Client
 }
 
 type Resource struct {
-	k8sClient k8sclient.Interface
-	logger    micrologger.Logger
+	k8sClient       k8sclient.Interface
+	logger          micrologger.Logger
+	legacyOrgClient *companyclient.Client
 }
 
 func New(config Config) (*Resource, error) {
@@ -46,10 +50,14 @@ func New(config Config) (*Resource, error) {
 
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
+	if config.LegacyOrgClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.LegacyOrgClient must not be empty", config)
+	}
 
 	r := &Resource{
-		k8sClient: config.K8sClient,
-		logger:    config.Logger,
+		k8sClient:       config.K8sClient,
+		logger:          config.Logger,
+		legacyOrgClient: config.LegacyOrgClient,
 	}
 
 	return r, nil

--- a/service/service.go
+++ b/service/service.go
@@ -5,15 +5,18 @@ package service
 import (
 	"context"
 	"sync"
+	"time"
 
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/security/v1alpha1"
 	companyclient "github.com/giantswarm/companyd-client-go"
+	credentialclient "github.com/giantswarm/credentiald/v2/client"
 	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
 	"github.com/giantswarm/k8sclient/v4/pkg/k8srestconfig"
 	"github.com/giantswarm/microendpoint/service/version"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/viper"
+	"gopkg.in/resty.v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/giantswarm/organization-operator/flag"
@@ -108,13 +111,28 @@ func New(config Config) (*Service, error) {
 		}
 	}
 
+	var legacyCredentialClient *credentialclient.Client
+	{
+		c := credentialclient.Config{
+			Logger:     config.Logger,
+			RestClient: resty.New().SetTimeout(15 * time.Second).SetRetryCount(5),
+			Address:    config.Viper.GetString(config.Flag.Service.LegacyCredentials.Address),
+		}
+
+		legacyCredentialClient, err = credentialclient.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var orgController *controller.Organization
 	{
 
 		c := controller.OrganizationConfig{
-			K8sClient:       k8sClient,
-			Logger:          config.Logger,
-			LegacyOrgClient: legacyOrgClient,
+			K8sClient:              k8sClient,
+			Logger:                 config.Logger,
+			LegacyOrgClient:        legacyOrgClient,
+			LegacyCredentialClient: legacyCredentialClient,
 		}
 
 		orgController, err = controller.NewOrganization(c)


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/17121

This PR adds support for ensuring `companyd` organizations whenever `Organization` CRs get created or updated. It also will delete `companyd` organizations when `Organization` CRs get deleted, but only if there are no credentials set up.