### PR TITLE
Introduce local interfaces so third party dependencies are easy to mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Introduce local interfaces to make easier to test the organization handler.
+
 ## [0.8.0] - 2021-05-24
 
 ### Changed

--- a/service/controller/resource/organization/resource.go
+++ b/service/controller/resource/organization/resource.go
@@ -9,9 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	companyclient "github.com/giantswarm/companyd-client-go"
-	credentialclient "github.com/giantswarm/credentiald/v2/client"
-
 	"github.com/giantswarm/organization-operator/pkg/label"
 	"github.com/giantswarm/organization-operator/pkg/project"
 )
@@ -34,15 +31,15 @@ var (
 type Config struct {
 	K8sClient              k8sclient.Interface
 	Logger                 micrologger.Logger
-	LegacyOrgClient        *companyclient.Client
-	LegacyCredentialClient *credentialclient.Client
+	LegacyOrgClient        CompanydClient
+	LegacyCredentialClient CredentialdClient
 }
 
 type Resource struct {
 	k8sClient              k8sclient.Interface
 	logger                 micrologger.Logger
-	legacyOrgClient        *companyclient.Client
-	legacyCredentialClient *credentialclient.Client
+	legacyOrgClient        CompanydClient
+	legacyCredentialClient CredentialdClient
 }
 
 func New(config Config) (*Resource, error) {

--- a/service/controller/resource/organization/spec.go
+++ b/service/controller/resource/organization/spec.go
@@ -1,0 +1,17 @@
+package organization
+
+import (
+	"context"
+
+	companyclient "github.com/giantswarm/companyd-client-go"
+	"github.com/giantswarm/credentiald/v2/service/lister"
+)
+
+type CompanydClient interface {
+	CreateCompany(companyID string, fields companyclient.CompanyFields) error
+	DeleteCompany(companyID string) error
+}
+
+type CredentialdClient interface {
+	List(ctx context.Context, request lister.Request) ([]lister.Response, error)
+}


### PR DESCRIPTION
I have an older PR which added a unit test to the creation logic. Since then, a couple of new dependencies and more logic have been added.
My thinking here is that I can introduce this local interfaces so it's easier to mock those dependencies from [the test I wrote in the other PR](https://github.com/giantswarm/organization-operator/pull/83).

## Checklist

- [X] Update changelog in CHANGELOG.md.
