### PR TITLE
Azure subscription annotation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,19 @@ workflows:
 
       - architect/push-to-docker:
           context: "architect"
+          name: push-organization-operator-to-dockerhub
+          image: "docker.io/giantswarm/organization-operator"
+          username_envar: "DOCKER_USERNAME"
+          password_envar: "DOCKER_PASSWORD"
+          requires:
+            - go-build
+          # Needed to trigger job also on git tag.
+          filters:
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-docker:
+          context: "architect"
           name: push-organization-operator-to-aliyun
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/organization-operator"
           username_envar: "ALIYUN_USERNAME"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure `Organization` CR in Azure MCs have the `subscriptionid` annotation set.
 
+### Changed
+
+- Use `Patch` to save `Namespace` in `Status` to avoid write conflicts.
+
 ## [0.9.0] - 2021-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ensure `Organization` CR in Azure MCs have the `subscriptionid` annotation set.
+
 ## [0.9.0] - 2021-07-05
 
 ### Added

--- a/helm/organization-operator/templates/rbac.yaml
+++ b/helm/organization-operator/templates/rbac.yaml
@@ -14,6 +14,13 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - secrets
+    verbs:
+      - "list"
+      - "get"
+  - apiGroups:
+      - ""
+    resources:
       - configmaps
       - namespaces
     verbs:

--- a/service/controller/resource/organization/create.go
+++ b/service/controller/resource/organization/create.go
@@ -29,6 +29,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 	}
 
+	err = r.ensureOrganizationHasSubscriptionIdAnnotation(ctx, org)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	orgNamespace := newOrganizationNamespace(org.Name)
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating organization namespace %#q", orgNamespace.Name))
 

--- a/service/controller/resource/organization/create.go
+++ b/service/controller/resource/organization/create.go
@@ -47,8 +47,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created organization namespace %#q", orgNamespace.Name))
 
-	org.Status.Namespace = orgNamespace.Name
-	err = r.k8sClient.CtrlClient().Status().Update(ctx, &org)
+	patch := []byte(fmt.Sprintf(`{"status":{"namespace": "%s"}}`, orgNamespace.Name))
+	err = r.k8sClient.CtrlClient().Patch(ctx, &org, ctrl.RawPatch(types.MergePatchType, patch))
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/organization/create.go
+++ b/service/controller/resource/organization/create.go
@@ -88,7 +88,7 @@ func (r *Resource) ensureOrganizationHasSubscriptionIdAnnotation(ctx context.Con
 	if subscription, ok := secret.Data["azure.azureoperator.subscriptionid"]; ok {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting subscriptionid annotation to %q for organization %q", string(subscription), organization.Name))
 		patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"subscription": "%s"}}}`, string(subscription)))
-		err = r.k8sClient.CtrlClient().Patch(ctx, &organization, ctrl.RawPatch(types.StrategicMergePatchType, patch))
+		err = r.k8sClient.CtrlClient().Patch(ctx, &organization, ctrl.RawPatch(types.MergePatchType, patch))
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/resource/organization/create.go
+++ b/service/controller/resource/organization/create.go
@@ -85,7 +85,7 @@ func (r *Resource) ensureOrganizationHasSubscriptionIdAnnotation(ctx context.Con
 	}
 
 	// The subscription id field is missing in non azure installations so it's ok.
-	if subscription, ok := secret.Data["azure.azureoperator.subscriptionid"]; ok {
+	if subscription, ok := secret.Data["azure.azureoperator.subscriptionid"]; ok && len(subscription) > 0 {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting subscriptionid annotation to %q for organization %q", string(subscription), organization.Name))
 		patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"subscription": "%s"}}}`, string(subscription)))
 		err = r.k8sClient.CtrlClient().Patch(ctx, &organization, ctrl.RawPatch(types.MergePatchType, patch))
@@ -93,7 +93,7 @@ func (r *Resource) ensureOrganizationHasSubscriptionIdAnnotation(ctx context.Con
 			return microerror.Mask(err)
 		}
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("azure.azureoperator.subscriptionid field not found in secret %q", secret.Name))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("azure.azureoperator.subscriptionid field not found or empty in secret %q", secret.Name))
 	}
 
 	return nil

--- a/service/controller/resource/organization/error.go
+++ b/service/controller/resource/organization/error.go
@@ -4,6 +4,10 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }

--- a/service/controller/resource/organization/error.go
+++ b/service/controller/resource/organization/error.go
@@ -4,8 +4,13 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
-var executionFailedError = &microerror.Error{
-	Kind: "executionFailedError",
+var secretNotFoundError = &microerror.Error{
+	Kind: "secretNotFoundError",
+}
+
+// IsSecretNotFound asserts secretNotFoundError.
+func IsSecretNotFound(err error) bool {
+	return microerror.Cause(err) == secretNotFoundError
 }
 
 var invalidConfigError = &microerror.Error{


### PR DESCRIPTION
CAPZ clusters need to have the `spec.subscriptionid` field set in `AzureCluster` CRs.
Because of a limit in Kyverno, we are not able to read plain text secret data in our policies.
This PR ensures a new annotation `subscriptionid` is ensured in the organization crs to allow kyverno to read the subscription id a cluster belongs to and default the required field in `AzureCluster`.

For non azure MCs the changes in this PR do nothing.

See also: https://github.com/giantswarm/kyverno-policies/pull/125

## Checklist

- [x] Update changelog in CHANGELOG.md.
