### PR TITLE
Added the use of the runtime/default seccomp profile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the use of the runtime/default seccomp profile.
+
 ## [1.0.5] - 2023-01-16
 
 ## [1.0.4] - 2022-11-15

--- a/helm/organization-operator/templates/deployment.yaml
+++ b/helm/organization-operator/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
+        {{- with .Values.podSecurityContext }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end}}
       containers:
       - name: {{ include "name" . }}
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
@@ -55,6 +58,10 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           timeoutSeconds: 1
+        securityContext:
+          {{- with .Values.securityContext }}
+            {{- . | toYaml | nindent 10 }}
+          {{- end }}
         resources:
           requests:
             cpu: 100m

--- a/helm/organization-operator/templates/psp.yaml
+++ b/helm/organization-operator/templates/psp.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "resource.psp.name" . }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 spec:
   privileged: false
   fsGroup:

--- a/helm/organization-operator/values.schema.json
+++ b/helm/organization-operator/values.schema.json
@@ -34,6 +34,19 @@
                 }
             }
         },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "project": {
             "type": "object",
             "properties": {
@@ -55,6 +68,19 @@
                     "type": "object",
                     "properties": {
                         "dockerConfigJSON": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
                             "type": "string"
                         }
                     }

--- a/helm/organization-operator/values.yaml
+++ b/helm/organization-operator/values.yaml
@@ -13,3 +13,13 @@ registry:
   domain: docker.io
   pullSecret:
     dockerConfigJSON: ""
+
+# Add seccomp to pod security context
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+# Add seccomp to container security context
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
I've modified the container and pod securitycontexts to let this application make use of the runtime/default seccomp profile. During testing this did not seem to interrupt any functionality. Please confirm this if possible.
This is done in light of:

https://github.com/giantswarm/roadmap/issues/259

Drop a message on slack if you've got questions.