### PR TITLE
Fixed Organization CR deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 TODO
 /organization-operator
 !vendor/**
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the use of the runtime/default seccomp profile.
 
+### Fixed
+
+- Prevented deletion of Organization CR until the organization namespace is deleted successfully
+
 ## [1.0.5] - 2023-01-16
 
 ## [1.0.4] - 2022-11-15

--- a/service/controller/org_test.go
+++ b/service/controller/org_test.go
@@ -3,12 +3,13 @@ package controller
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	companyclient "github.com/giantswarm/companyd-client-go"
 	credentialclient "github.com/giantswarm/credentiald/v2/client"
 	"github.com/giantswarm/k8sclient/v6/pkg/k8sclient"
 	"github.com/giantswarm/micrologger/microloggertest"
-	"github.com/giantswarm/organization-operator/api/v1alpha1"
-	"github.com/giantswarm/organization-operator/service/unittest"
 	"gopkg.in/resty.v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -17,8 +18,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"testing"
-	"time"
+
+	"github.com/giantswarm/organization-operator/api/v1alpha1"
+	"github.com/giantswarm/organization-operator/service/unittest"
 )
 
 const (

--- a/service/controller/org_test.go
+++ b/service/controller/org_test.go
@@ -1,0 +1,239 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	companyclient "github.com/giantswarm/companyd-client-go"
+	credentialclient "github.com/giantswarm/credentiald/v2/client"
+	"github.com/giantswarm/k8sclient/v6/pkg/k8sclient"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/organization-operator/api/v1alpha1"
+	"github.com/giantswarm/organization-operator/service/unittest"
+	"gopkg.in/resty.v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"testing"
+	"time"
+)
+
+const (
+	testFinalizer = "test.finalizers.giantswarm.io/test-finalizer"
+	orgFinalizer  = "operatorkit.giantswarm.io/organization-operator-organization-controller"
+)
+
+func Test_OrgReconcileDeleteStep(t *testing.T) {
+	testCases := []struct {
+		name                string
+		organizationName    string
+		namespaceFinalizers []string
+	}{
+		{
+			name:                "case 0: Delete org in case there is no org namespace",
+			organizationName:    "giantswarm",
+			namespaceFinalizers: nil,
+		},
+		{
+			name:                "case 1: Keep org and delete org namespace in case it has no finalizers",
+			organizationName:    "giantswarm",
+			namespaceFinalizers: []string{},
+		},
+		{
+			name:                "case 2: Keep org and org namespace in case it has finalizers",
+			organizationName:    "giantswarm",
+			namespaceFinalizers: []string{testFinalizer},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			namespace := newOrgNamespace(tc.organizationName, tc.namespaceFinalizers)
+			org := newOrg(tc.organizationName, namespace.Name)
+
+			runtimeObjects := []runtime.Object{org}
+			if tc.namespaceFinalizers != nil {
+				runtimeObjects = append(runtimeObjects, namespace)
+			}
+
+			ctx := context.Background()
+			k8sClient := unittest.FakeK8sClient(runtimeObjects...)
+
+			orgController, err := newOrgController(k8sClient)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req := newOrgReconcileRequest(org.Name)
+			_, err = orgController.Reconcile(ctx, req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			org = &v1alpha1.Organization{}
+			err = k8sClient.CtrlClient().Get(ctx, client.ObjectKey{Name: tc.organizationName}, org)
+			if tc.namespaceFinalizers == nil && (err == nil || !errors.IsNotFound(err)) {
+				t.Fatal(err)
+			} else if tc.namespaceFinalizers != nil {
+				if err != nil {
+					t.Fatal(err)
+				}
+				orgNamespace := &corev1.Namespace{}
+				err = k8sClient.CtrlClient().Get(ctx, client.ObjectKey{Name: namespace.Name}, orgNamespace)
+				if len(tc.namespaceFinalizers) == 0 && err == nil {
+					t.Fatalf("found unexpected namespace %s", namespace.Name)
+				} else if len(tc.namespaceFinalizers) == 0 && !errors.IsNotFound(err) {
+					t.Fatal(err)
+				} else if len(tc.namespaceFinalizers) > 0 && err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func Test_OrgReconcileDelete(t *testing.T) {
+
+	testCases := []struct {
+		name                string
+		organizationName    string
+		namespaceFinalizers []string
+		expectedIterations  int
+	}{
+		{
+			name:                "case 0: Delete organization after deleting namespace",
+			organizationName:    "giantswarm",
+			namespaceFinalizers: []string{testFinalizer},
+			expectedIterations:  5,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			namespace := newOrgNamespace(tc.organizationName, tc.namespaceFinalizers)
+			org := newOrg(tc.organizationName, namespace.Name)
+
+			ctx := context.Background()
+			k8sClient := unittest.FakeK8sClient(org, namespace)
+
+			orgController, err := newOrgController(k8sClient)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req := newOrgReconcileRequest(org.Name)
+
+			for i := 0; i < tc.expectedIterations; i++ {
+				remainingIterations := tc.expectedIterations - i - 1
+
+				orgNamespace := &corev1.Namespace{}
+				err = k8sClient.CtrlClient().Get(ctx, client.ObjectKey{Name: namespace.Name}, orgNamespace)
+
+				if remainingIterations == 0 {
+					if err == nil {
+						t.Fatalf("unexpected namespace %s found", namespace.Name)
+					} else if !errors.IsNotFound(err) {
+						t.Fatal(err)
+					}
+				} else {
+					if err != nil {
+						t.Fatal(err)
+					}
+					if remainingIterations == 1 {
+						orgNamespace.Finalizers = []string{}
+						err = k8sClient.CtrlClient().Update(ctx, orgNamespace)
+						if err != nil {
+							t.Fatal(err)
+						}
+					} else {
+						if len(orgNamespace.Finalizers) == 0 {
+							t.Fatalf("namespace %s has no finalizers", orgNamespace.Name)
+						}
+					}
+					org = &v1alpha1.Organization{}
+					err = k8sClient.CtrlClient().Get(ctx, client.ObjectKey{Name: tc.organizationName}, org)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				_, err = orgController.Reconcile(ctx, req)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			org = &v1alpha1.Organization{}
+			err = k8sClient.CtrlClient().Get(ctx, client.ObjectKey{Name: tc.organizationName}, org)
+			if err == nil {
+				t.Fatalf("found unexpected organization %s", org.Name)
+			} else if !errors.IsNotFound(err) {
+				t.Fatal(err)
+			}
+		})
+	}
+
+}
+
+func newOrgController(k8sClient k8sclient.Interface) (*Organization, error) {
+	logger := microloggertest.New()
+
+	legacyOrgClient, err := companyclient.Dial("http://companydserver")
+	if err != nil {
+		return nil, err
+	}
+
+	credentialClientConfig := credentialclient.Config{
+		Logger:     logger,
+		RestClient: resty.New(),
+		Address:    "http://credentialdserver",
+	}
+
+	legacyCredentialClient, err := credentialclient.New(credentialClientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	config := OrganizationConfig{
+		K8sClient:              k8sClient,
+		Logger:                 logger,
+		LegacyOrgClient:        legacyOrgClient,
+		LegacyCredentialClient: legacyCredentialClient,
+	}
+
+	return NewOrganization(config)
+}
+func newOrg(name, namespace string) *v1alpha1.Organization {
+	return &v1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Finalizers:        []string{orgFinalizer},
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+		},
+		Spec: v1alpha1.OrganizationSpec{},
+		Status: v1alpha1.OrganizationStatus{
+			Namespace: namespace,
+		},
+	}
+}
+
+func newOrgNamespace(orgName string, finalizers []string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       fmt.Sprintf("org-%s", orgName),
+			Finalizers: finalizers,
+		},
+	}
+}
+
+func newOrgReconcileRequest(orgName string) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: orgName,
+		},
+	}
+}

--- a/service/controller/org_test.go
+++ b/service/controller/org_test.go
@@ -8,7 +8,7 @@ import (
 
 	companyclient "github.com/giantswarm/companyd-client-go"
 	credentialclient "github.com/giantswarm/credentiald/v2/client"
-	"github.com/giantswarm/k8sclient/v6/pkg/k8sclient"
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"gopkg.in/resty.v1"
 	corev1 "k8s.io/api/core/v1"

--- a/service/controller/resource/organization/delete.go
+++ b/service/controller/resource/organization/delete.go
@@ -3,6 +3,7 @@ package organization
 import (
 	"context"
 	"fmt"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	legacyCredentialLister "github.com/giantswarm/credentiald/v2/service/lister"

--- a/service/unittest/default_k8sclient.go
+++ b/service/unittest/default_k8sclient.go
@@ -13,14 +13,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake" // nolint:staticcheck
 
 	securityv1alpha1 "github.com/giantswarm/organization-operator/api/v1alpha1"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
 )
 
 type fakeK8sClient struct {
 	ctrlClient client.Client
+	k8sClient  kubernetes.Interface
 	scheme     *runtime.Scheme
 }
 
-func FakeK8sClient(initObjs ...client.Object) k8sclient.Interface {
+func FakeK8sClient(initObjs ...runtime.Object) k8sclient.Interface {
 	var err error
 
 	var k8sClient k8sclient.Interface
@@ -36,7 +38,8 @@ func FakeK8sClient(initObjs ...client.Object) k8sclient.Interface {
 		}
 
 		k8sClient = &fakeK8sClient{
-			ctrlClient: fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjs...).Build(),
+			ctrlClient: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjs...).Build(),
+			k8sClient:  clientgofake.NewSimpleClientset(),
 			scheme:     scheme,
 		}
 	}
@@ -61,7 +64,7 @@ func (f *fakeK8sClient) ExtClient() clientset.Interface {
 }
 
 func (f *fakeK8sClient) K8sClient() kubernetes.Interface {
-	return nil
+	return f.k8sClient
 }
 
 func (f *fakeK8sClient) RESTClient() rest.Interface {

--- a/service/unittest/default_k8sclient.go
+++ b/service/unittest/default_k8sclient.go
@@ -12,8 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake" // nolint:staticcheck
 
-	securityv1alpha1 "github.com/giantswarm/organization-operator/api/v1alpha1"
 	clientgofake "k8s.io/client-go/kubernetes/fake"
+
+	securityv1alpha1 "github.com/giantswarm/organization-operator/api/v1alpha1"
 )
 
 type fakeK8sClient struct {


### PR DESCRIPTION
This PR blocks Organization CR deletion until the organization namespace is deleted successfully.

Finalizer on the Organization CR are kept until the organization namespace no longer exists. Then the finalizer is removed and the deletion of the CR is unblocked.

## Checklist

- [x] Update changelog in CHANGELOG.md.
