### PR TITLE
Updated nancyignore

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -21,3 +21,6 @@ CVE-2021-41803 until=2024-01-01
 
 # caddyserver/caddy@v1.0.3
 CVE-2022-29718 until=2023-06-01
+
+# golang/k8s.io/apiserver@v0.25.0 - no fix yet
+CVE-2020-8561

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -23,4 +23,4 @@ CVE-2021-41803 until=2024-01-01
 CVE-2022-29718 until=2023-06-01
 
 # golang/k8s.io/apiserver@v0.25.0 - no fix yet
-CVE-2020-8561
+CVE-2020-8561 until=2023-06-01


### PR DESCRIPTION
Nancy reported a new CVE in golang/k8s.io/apiserver@v0.25.0. There is a newer version of the package, but it is still vulnerable. Aslo, it contains breaking changes. Therefore the current version of the package was kept and the CVE was added to nancyignore.

## Checklist

- [x] Update changelog in CHANGELOG.md.
