### PR TITLE
Disable logger development mode to avoid panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Disable zap logger development mode to avoid panicking
 - Ownership change to Shield
 
 ## [2.0.1] - 2024-08-13

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
## Checklist
This PR:
### Fixes
- Disables zap logger development mode to avoid panicking


- [x] Update changelog in CHANGELOG.md.
