### PR TITLE
Remove Quay Repository badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![CircleCI](https://circleci.com/gh/giantswarm/organization-operator.svg?&style=shield)](https://circleci.com/gh/giantswarm/organization-operator)
-[![Docker Repository on Quay](https://quay.io/repository/giantswarm/organization-operator/status "Docker Repository on Quay")](https://quay.io/repository/giantswarm/organization-operator)
 
 # organization-operator
 


### PR DESCRIPTION
Quay is no longer relevant